### PR TITLE
Keep source directory for topsStack

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,7 +69,6 @@ RUN set -ex \
  && scons install \
  && cp docker/isce_env.sh $ISCE_INSTALL_ROOT \
  && cd /tmp \
- && rm -rf /opt/isce2/src \
  && mkdir -p /tmp/rpm-build/opt \
  && mv $ISCE_INSTALL_ROOT /tmp/rpm-build/opt \
  && curl -s https://api.github.com/repos/$ISCE_ORG/isce2/git/refs/heads/master \


### PR DESCRIPTION
@pymonger 

The topsStack components are missing in hysds/isce2 docker image

This is because:
As per this [ReadMe](https://github.com/isce-framework/isce2/tree/master/contrib/stack#installation), topsStack is not included into $ISCE_HOME (/opt/isce2/isce) after installation, hence, the source code needs to be retained.

However, the isce2 source code is removed in the original hysds/isce2 docker.

Proposing to retain the source code in `/opt/isce2/src/isce2`

Once this is merged, rebuilt and pushed to Dockerhub, we can remove these lines in the topsStack PGE: https://github.com/aria-jpl/topsstack/pull/5/files#diff-ebacf6f6ae4ee68078bb16454b23247dR10-R13
